### PR TITLE
Bree pages fix

### DIFF
--- a/wiki/docs/wiki/entities/good/Bree-Hobbit.md
+++ b/wiki/docs/wiki/entities/good/Bree-Hobbit.md
@@ -15,7 +15,7 @@ title: Bree-Hobbit
 image: entities/bree-hobbit.png
 armor: 0
 hitpoints: 16
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-Hobbit

--- a/wiki/docs/wiki/entities/good/Bree-Hobbit.md
+++ b/wiki/docs/wiki/entities/good/Bree-Hobbit.md
@@ -28,7 +28,7 @@ Bree-Hobbits can spawn any time of the day. They are only found in Bree-land.
   
 ## Behavior
 
-Hobbits are passive mobs. They will flee from Orcs, Wargs, or when attacked by other mobs. Upon killing a Bree-Hobbit, you will be bestowed the advancement **"Bree-hobbit Slayer"**
+Hobbits are passive mobs. They will flee from Orcs, Wargs, or when attacked by other mobs. This behaviour is true of all Bree-Hobbit traders. Upon killing a Bree-Hobbit, you will be bestowed the advancement **"Bree-hobbit Slayer"**
   
 ## Hiring
 

--- a/wiki/docs/wiki/entities/good/Bree-Man.md
+++ b/wiki/docs/wiki/entities/good/Bree-Man.md
@@ -15,7 +15,7 @@ title: Bree-Man
 image: entities/bree-man.png
 armor: 0
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-Man

--- a/wiki/docs/wiki/entities/good/Bree-Man.md
+++ b/wiki/docs/wiki/entities/good/Bree-Man.md
@@ -44,7 +44,7 @@ They can be hired for 20 coins from a[[bree-land_sheriff|Bree-land Sheriff]] whe
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 
 ## History
 - Renewed 5.0:

--- a/wiki/docs/wiki/entities/good/Bree-Man.md
+++ b/wiki/docs/wiki/entities/good/Bree-Man.md
@@ -4,7 +4,7 @@ tags:
 show:
   - toc
 alias:
-  - bree-man
+  - bree_man
 ---
 
 ####

--- a/wiki/docs/wiki/entities/good/Bree-land_Baker.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Baker.md
@@ -62,6 +62,8 @@ The Bree-land people were men who wandered over the Misty Mountains but did not 
 ## History
 - 1.7.3:
     - Ported Bree-land Bakers.
+- 1.8.0:
+    - Ported Bree-Hobbit Bakers.
 
 ## Trivia
 

--- a/wiki/docs/wiki/entities/good/Bree-land_Baker.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Baker.md
@@ -15,7 +15,7 @@ title: Bree-land Baker
 image: entities/bree-land_baker.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 ::infobox
@@ -24,7 +24,7 @@ title: Bree-Hobbit Baker
 image: entities/bree-hobbit_baker.png
 armor: None
 hitpoints: 16
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Baker

--- a/wiki/docs/wiki/entities/good/Bree-land_Baker.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Baker.md
@@ -57,7 +57,7 @@ Bree-land Bakers also buy many supplies, such as berries and wheat.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 
 ## History
 - 1.7.3:

--- a/wiki/docs/wiki/entities/good/Bree-land_Brewer.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Brewer.md
@@ -15,7 +15,16 @@ title: Bree-land Brewer
 image: entities/bree-land_brewer.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
+::end-infobox
+
+::infobox
+type: entity
+title: Bree-Hobbit Brewer
+image: entities/bree-hobbit_brewer.png
+armor: None
+hitpoints: 16
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Brewer
@@ -26,19 +35,6 @@ The Bree-land Brewer is a trader that specializes in alcoholic beverages.
 
 The Bree-land Brewer spawns in the brewery, found in Bree-land villages.
 
-## Variants
-
-The Bree-land Brewer has one variant, the Bree-Hobbit Brewer.
-
-::infobox
-type: entity
-title: Bree-Hobbit Brewer
-image: entities/bree-hobbit_brewer.png
-armor: None
-hitpoints: 16
-faction: [[bree-land_faction|Bree-land]]
-::end-infobox
-  
 ## Behavior
 
 Bree-land Brewers will wander around their brewery when not selling goods. Upon death, a silver coin will float above the ground where they died, signifying that they will respawn here after a short period of time.

--- a/wiki/docs/wiki/entities/good/Bree-land_Brewer.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Brewer.md
@@ -61,6 +61,8 @@ The Bree-land people were men who wandered over the Misty Mountains but did not 
 ## History
 - 1.7.3:
     - Ported Bree-land Brewers.
+- 1.8.0:
+    - Ported Bree-Hobbit Brewers.
 
 ## Trivia
 

--- a/wiki/docs/wiki/entities/good/Bree-land_Brewer.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Brewer.md
@@ -57,8 +57,7 @@ Bree-land Brewers also buy many supplies, such as food and drink ingredients.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.3:
     - Ported Bree-land Brewers.

--- a/wiki/docs/wiki/entities/good/Bree-land_Butcher.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Butcher.md
@@ -13,11 +13,18 @@ alias:
 type: entity
 title: Bree-land Butcher
 image: entities/bree-land_butcher.png
-image: entities/bree-hobbit_butcher.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
-variants: Bree-Hobbit Butcher (16 hp)
+faction: [[bree_faction|Bree-land]]
+::end-infobox
+
+::infobox
+type: entity
+title: Bree-Hobbit Butcher
+image: entities/bree-hobbit_butcher.png
+armor: None
+hitpoints: 16
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Butcher

--- a/wiki/docs/wiki/entities/good/Bree-land_Butcher.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Butcher.md
@@ -62,6 +62,8 @@ The Bree-land people were men who wandered over the Misty Mountains but did not 
 ## History
 - 1.7.3:
     - Ported Bree-land Butchers.
+- 1.8.0:
+    - Ported Bree-Hobbit Butchers.
 
 ## Trivia
 

--- a/wiki/docs/wiki/entities/good/Bree-land_Butcher.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Butcher.md
@@ -57,7 +57,7 @@ Bree-land Butchers also buy many supplies, such as knives and metal ingots.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them. 
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them. 
 
 ## History
 - 1.7.3:

--- a/wiki/docs/wiki/entities/good/Bree-land_Cheesemonger.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Cheesemonger.md
@@ -48,8 +48,7 @@ Bree-land Cheesemongers also buy many supplies, such as knifes and mushrooms.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.3:
     - Added Bree-land Cheesemongers.

--- a/wiki/docs/wiki/entities/good/Bree-land_Cheesemonger.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Cheesemonger.md
@@ -15,7 +15,7 @@ title: Bree-land Cheesemonger
 image: entities/bree-land_cheesemonger.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Cheesemonger

--- a/wiki/docs/wiki/entities/good/Bree-land_Farmer.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Farmer.md
@@ -48,8 +48,7 @@ Bree-land Farmers also buy many supplies, such as hoes and buckets.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.1:
     - Ported Bree-land Farmers.

--- a/wiki/docs/wiki/entities/good/Bree-land_Farmer.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Farmer.md
@@ -15,7 +15,7 @@ title: Bree-land Farmer
 image: entities/bree-land_farmer.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Farmer

--- a/wiki/docs/wiki/entities/good/Bree-land_Florist.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Florist.md
@@ -61,6 +61,8 @@ The Bree-land people were men who wandered over the Misty Mountains but did not 
 ## History
 - 1.7.3:
     - Ported Bree-land Florists.
+- 1.8.0:
+    - Ported Bree-Hobbit Florists.
 
 ## Trivia
 

--- a/wiki/docs/wiki/entities/good/Bree-land_Florist.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Florist.md
@@ -15,7 +15,16 @@ title: Bree-land Florist
 image: entities/bree-land_florist.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
+::end-infobox
+
+::infobox
+type: entity
+title: Bree-Hobbit Florist
+image: entities/bree-hobbit_florist.png
+armor: None
+hitpoints: 16
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Florist

--- a/wiki/docs/wiki/entities/good/Bree-land_Florist.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Florist.md
@@ -57,8 +57,7 @@ Bree-land Florists also buy many supplies, such as hoes and shovels.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.3:
     - Ported Bree-land Florists.

--- a/wiki/docs/wiki/entities/good/Bree-land_Guard.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Guard.md
@@ -4,7 +4,7 @@ tags:
 show:
   - toc
 alias:
-  - bree-land_guard
+  - bree_guard
 ---
 
 ####

--- a/wiki/docs/wiki/entities/good/Bree-land_Guard.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Guard.md
@@ -46,8 +46,7 @@ They can be hired for 40 coins from a[[bree-land_sheriff|Bree-land Sheriff]] whe
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - Renewed 5.0:
     - Ported Bree-land Guards

--- a/wiki/docs/wiki/entities/good/Bree-land_Guard.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Guard.md
@@ -15,7 +15,7 @@ title: Bree-land Guard
 image: entities/bree-land_guard.png
 armor: Varies
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Guard

--- a/wiki/docs/wiki/entities/good/Bree-land_Innkeeper.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Innkeeper.md
@@ -61,6 +61,8 @@ The Bree-land people were men who wandered over the Misty Mountains but did not 
 ## History
 - 1.7.3:
     - Ported Bree-land Innkeepers.
+- 1.8.0:
+    - Ported Bree-Hobbit Innkeepers.
 
 ## Trivia
 

--- a/wiki/docs/wiki/entities/good/Bree-land_Innkeeper.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Innkeeper.md
@@ -15,7 +15,16 @@ title: Bree-land Innkeeper
 image: entities/bree-land_innkeeper.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
+::end-infobox
+
+::infobox
+type: entity
+title: Bree-Hobbit Innkeeper
+image: entities/bree-hobbit_innkeeper.png
+armor: None
+hitpoints: 16
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Innkeeper

--- a/wiki/docs/wiki/entities/good/Bree-land_Innkeeper.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Innkeeper.md
@@ -57,8 +57,7 @@ Bree-land Innkeepers also buy many supplies, such as raw food, mugs, and pipewee
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.3:
     - Ported Bree-land Innkeepers.

--- a/wiki/docs/wiki/entities/good/Bree-land_Leatherworker.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Leatherworker.md
@@ -48,8 +48,7 @@ Bree-land Leatherworkers also buy many supplies, such as furs.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.3:
     - Ported Bree-land Leatherworkers.

--- a/wiki/docs/wiki/entities/good/Bree-land_Leatherworker.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Leatherworker.md
@@ -15,7 +15,7 @@ title: Bree-land Leatherworker
 image: entities/bree-land_leatherworker.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Leatherworker

--- a/wiki/docs/wiki/entities/good/Bree-land_Lumberman.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Lumberman.md
@@ -48,8 +48,7 @@ Bree-land Lumbermen also buy many supplies, such as axes and shears.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.3:
     - Ported Bree-land Lumbermen.

--- a/wiki/docs/wiki/entities/good/Bree-land_Lumberman.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Lumberman.md
@@ -15,7 +15,7 @@ title: Bree-land Lumberman
 image: entities/bree-land_lumberman.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Lumberman

--- a/wiki/docs/wiki/entities/good/Bree-land_Merchant.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Merchant.md
@@ -48,8 +48,7 @@ Bree-land Merchants also buy many supplies, such as food.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.0:
     - Added Bree-land Merchants.

--- a/wiki/docs/wiki/entities/good/Bree-land_Merchant.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Merchant.md
@@ -15,7 +15,7 @@ title: Bree-land Merchant
 image: entities/bree-land_merchant.png
 armor: None
 hitpoints: 25
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Merchant

--- a/wiki/docs/wiki/entities/good/Bree-land_Potter.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Potter.md
@@ -15,7 +15,16 @@ title: Bree-land Potter
 image: entities/bree-land_potter.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
+::end-infobox
+
+::infobox
+type: entity
+title: Bree-Hobbit Potter
+image: entities/bree-hobbit_potter.png
+armor: None
+hitpoints: 16
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Potter

--- a/wiki/docs/wiki/entities/good/Bree-land_Potter.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Potter.md
@@ -57,8 +57,7 @@ Bree-land Potters also buy many supplies, such as shovels and clay.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.1:
     - Added Bree-land Potters.

--- a/wiki/docs/wiki/entities/good/Bree-land_Potter.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Potter.md
@@ -61,6 +61,8 @@ The Bree-land people were men who wandered over the Misty Mountains but did not 
 ## History
 - 1.7.1:
     - Added Bree-land Potters.
+- 1.8.0:
+    - Added Bree-Hobbit Potters.
 
 ## Trivia
 

--- a/wiki/docs/wiki/entities/good/Bree-land_Sheriff.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Sheriff.md
@@ -15,7 +15,7 @@ title: Bree-land Sheriff
 image: entities/bree-land_sheriff.png
 armor: Varies
 hitpoints: 25
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Sheriff

--- a/wiki/docs/wiki/entities/good/Bree-land_Sheriff.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Sheriff.md
@@ -44,8 +44,7 @@ Bree-land Sheriffs allow you to hire Bree-hobbits, Bree-Men, or Bree-land Guards
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.1:
     - Ported Bree-land Sheriffs

--- a/wiki/docs/wiki/entities/good/Bree-land_Smith.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Smith.md
@@ -48,8 +48,7 @@ Bree-land Smiths also buy many supplies, such as ingots and gems.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
-
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 ## History
 - 1.7.3:
     - Ported Bree-land Smiths.

--- a/wiki/docs/wiki/entities/good/Bree-land_Smith.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Smith.md
@@ -15,7 +15,7 @@ title: Bree-land Smith
 image: entities/bree-land_smith.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Smith

--- a/wiki/docs/wiki/entities/good/Bree-land_Stablemaster.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Stablemaster.md
@@ -48,7 +48,7 @@ Bree-land Stablemasters also buy many supplies, such as animal feed.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 
 ## History
 - 1.7.3:

--- a/wiki/docs/wiki/entities/good/Bree-land_Stablemaster.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Stablemaster.md
@@ -15,7 +15,7 @@ title: Bree-land Stablemaster
 image: entities/bree-land_stablemaster.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Stablemaster

--- a/wiki/docs/wiki/entities/good/Bree-land_Stonemason.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Stonemason.md
@@ -15,7 +15,7 @@ title: Bree-land Stonemason
 image: entities/bree-land_stonemason.png
 armor: None
 hitpoints: 20
-faction: [[bree-land_faction|Bree-land]]
+faction: [[bree_faction|Bree-land]]
 ::end-infobox
 
 # Bree-land Stonemason

--- a/wiki/docs/wiki/entities/good/Bree-land_Stonemason.md
+++ b/wiki/docs/wiki/entities/good/Bree-land_Stonemason.md
@@ -48,7 +48,7 @@ Bree-land Stonemasons also buy many supplies, such as food and pickaxes.
 
 ## Lore
 
-The Bree-land people were Edain who wandered over the Misty Mountains, found the land to be pleasent, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
+The Bree-land people were men who wandered over the Misty Mountains but did not continue west like the Edain. They found the area to be pleasant, and settled there for good. They were there before the Númenóreans, after the kingdom of Arnor, and will be forever according to them.
 
 ## History
 - 1.7.3:

--- a/wiki/docs/wiki/factions/Bree-land_(Faction).md
+++ b/wiki/docs/wiki/factions/Bree-land_(Faction).md
@@ -12,7 +12,7 @@ alias:
 # Bree-land
 
 ## NPCs
-- [bree-man|Bree-land Men and Women], [[bree-hobbit|Bree-Hobbits]] and [[bree-land_guard|Bree-land Guards]] spawn throughout much of the Breeland Biome during the day.
+- [bree_man|Bree-land Men and Women], [[bree-hobbit|Bree-Hobbits]] and [[bree_guard|Bree-land Guards]] spawn throughout much of the Breeland Biome during the day.
 
 - There are many Bree-land traders that are ported in Extended and they can be found in Bree-land Hamlets and Villages:
     - [[bree-land_baker|Bree-land Bakers]]

--- a/wiki/docs/wiki/factions/Bree-land_(Faction).md
+++ b/wiki/docs/wiki/factions/Bree-land_(Faction).md
@@ -12,7 +12,7 @@ alias:
 # Bree-land
 
 ## NPCs
-- [bree-man|Bree-land Men and Women], [[bree-hobbit|Bree-Hobbits]] and [[bree_guard|Bree-land Guards]] spawn throughout much of the Breeland Biome during the day.
+- [bree-man|Bree-land Men and Women], [[bree-hobbit|Bree-Hobbits]] and [[bree-land_guard|Bree-land Guards]] spawn throughout much of the Breeland Biome during the day.
 
 - There are many Bree-land traders that are ported in Extended and they can be found in Bree-land Hamlets and Villages:
     - [[bree-land_baker|Bree-land Bakers]]


### PR DESCRIPTION
Fixed Bree-land Faction links
Fixed Incorrect lore
Fixed Bree-Hobbit trader images
Added Bree-Hobbit trader's history
(Hopefully) Fixed Bree-man and Bree-land Guard links. (I have no clue why these don't already work. They are the same as the Bree-Hobbit link which works, so I just changed them a tiny bit.)